### PR TITLE
Fix win_x64 builds by adding manfiestUrl

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -282,6 +282,7 @@ module.exports = function(grunt) {
           cacheDir: './node_modules/nw',
           outDir: './dest/desktop/',
           managedManifest: './package.nw.json',
+          manifestUrl: 'https://nwjs.io/versions.json',
         },
         src: ['./dest/prod/**/*', "./package.json", "!./dest/desktop/"]
       },


### PR DESCRIPTION
Fixes #24
---
**Tested**
- Ran `npm run build:win` and built successfully on Windows
---
Merging this would resolve the immediate issue of `win_x64` builds failing, benefiting devs on Windows. However, given this seems to be a problem with `grunt-nw-builder` -> `nw-builder` dependency and the manifest download being instable, I wouldn't be surprised if this issue comes up again in future versions of nw-builder and future packages of nw.js